### PR TITLE
Fixed an issue with crc16, ...

### DIFF
--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -497,7 +497,7 @@ class XMODEM(object):
 
         '''
         for char in data:
-            crc = (crc << 8) ^ self.crctable[((crc >> 8) ^ ord(char)) & 0xff]
+            crc = ((crc << 8) ^ self.crctable[((crc >> 8) ^ ord(char)) & 0xff]) & 0xffff
         return crc & 0xffff
 
 


### PR DESCRIPTION
... where the temporary result wasn't truncated to 16bit. 

I'm using this library to communicate with an in-system-programmer for a microcontroller platform. I wanted to implement a verify feature and used xmodems calc_crc function, in order not to use another library. The following code would take forever (like 10-20 minutes) and return a long-integer, if the data set was large enough:

``` python
modem = xmodem.XMODEM(None,None)
crc = modem.calc_crc(data)
```

Truncating the temporary results to 16 bit fixed the problem.
