### PR TITLE
Concatenate packet to send single USB URB transfer

### DIFF
--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -302,9 +302,7 @@ class XMODEM(object):
             # emit packet
             while True:
                 self.log.debug('send: block %d', sequence)
-                self.putc(header)
-                self.putc(data)
-                self.putc(checksum)
+                self.putc(header+data+checksum)
                 char = self.getc(1, timeout)
                 if char == ACK:
                     success_count += 1


### PR DESCRIPTION
I attempted to use xmodem to upload firmware to a microcontroller. The CDC USB device programmed into the microcontroller expects the whole data packet (header+data+CRC) to be into a single URB (USB packet) so it did not work as it was. It was easily solved by forming a single packet concatenating the three strings. Note that the buggy implementation is actually that of the microcontroller.

It should not affect non-USB transmissions.
