### PR TITLE
remove stray `assert False` in order to fix #27

### DIFF
--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -560,7 +560,6 @@ class XMODEM(object):
                 data = self.getc(1, timeout=1)
                 if data is None:
                     break
-                assert False, data
             self.putc(NAK)
             # get next start-of-header byte
             char = self.getc(1, timeout)


### PR DESCRIPTION
If I understand the comment in the while loop correctly, the purpose of the while loop here is to throw away everything which is sent by the sender to empty the UART buffer, and wait until a timeout occurs (`if data is None`, i.e.  everything is sent, end of the current packet).  However, due to the `assert`, the loop terminates after the first byte, unless it timeouts (which will most probably not be the case on current connections).

Fixes #27