### PR TITLE
Embedded sender optimization

### DIFF
--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -518,6 +518,11 @@ class XMODEM(object):
                 seq2 = bytes([data[1]])
             if len(data) > 2:
                 data = data[2:]
+                # Sanity check data length here
+                if len(data) != (packet_size + 1 + crc_mode) :
+                    self.log.warn('recv: Serial data downloaded is wrong length.')
+                    # cancel processing of data?
+                    #seq2 = -1
             else:
                 data = None
 


### PR DESCRIPTION
The "read sequence" section of the recv method uses a method for reading serial that makes it more likely when talking to embedded systems to miss characters or to cause timeout issues. 

Generally, if you can try to read as much as possible as early as possible, you should. Also, not doing that makes it hard to reason about the delay times in the system. The getc function is called with the same timeout numerous times allowing those timeouts to stack up. Also, it can lead to bugs like in the failure case of the sequence check where no timeout is given. 

Instead, the code now tries to consume all the data that the producer is expected to send without response. Then, the code conditionally strips out the subset of that data to interpret.

There is a comment that I leave up to you to remove which is to cancel the processing of data if the lengths don’t match up. I am less certain about this specific change.