### PR TITLE
Fix typos

### DIFF
--- a/doc/XMODEM.TXT
+++ b/doc/XMODEM.TXT
@@ -5,7 +5,7 @@ Perception presents:
 
 This has to be one of the most internationally accepted protocols for upload-
  ing and downloading binary and text files.  It is fairly straight-forward as
- to how it is set up and there are some error checking capablities.
+ to how it is set up and there are some error checking capabilities.
 
 
 --- Before you begin ---
@@ -24,7 +24,7 @@ In order to send the file, you must first divide it into 128 byte sections
  make up the second packet, etc.
 
 The packet number sent is simply the number of the packet.  If the packet
- number is greater than 255, then subtract 256 repeatly until the number is
+ number is greater than 255, then subtract 256 repeatedly until the number is
  between 0 and 255.  For example, if you were sending packet 731, then you
  would send 731 - 256 - 256 = 219.
 
@@ -35,7 +35,7 @@ The 1's complement of a byte (to make life easy) is simply 255 minus the
 The checksum is the value of all the bytes in the packet added together.  For
  example, if the first five bytes were 45, 12, 64, 236, 173 and the other 123
  bytes were zeroes, the checksum would be 45+12+64+236+173+0+0+...+0 = 530.
- However, to make each block one byte smaller, they repeatly subtract 256
+ However, to make each block one byte smaller, they repeatedly subtract 256
  from the checksum until it is between 0 and 255.  In this case, the checksum
  would be 530 - 256 - 256 = 18.
 

--- a/doc/XMODEM1K.TXT
+++ b/doc/XMODEM1K.TXT
@@ -5,7 +5,7 @@ Perception presents:
 
 This has to be one of the most internationally accepted protocols for upload-
  ing and downloading binary and text files.  It is fairly straight-forward as
- to how it is set up and there are fairly good error checking capablities.
+ to how it is set up and there are fairly good error checking capabilities.
 
 
 --- Before you begin ---

--- a/doc/XMODMCRC.TXT
+++ b/doc/XMODMCRC.TXT
@@ -5,7 +5,7 @@ Perception presents:
 
 This has to be one of the most internationally accepted protocols for upload-
  ing and downloading binary and text files.  It is fairly straight-forward as
- to how it is set up and there are some error checking capablities.
+ to how it is set up and there are some error checking capabilities.
 
 
 --- Before you begin ---

--- a/doc/ymodem.txt
+++ b/doc/ymodem.txt
@@ -107,7 +107,7 @@ of weaknesses in the original protocol:
      timesharing systems, packet switched networks, satellite circuits,
      and buffered (error correcting) modems.
 
-   + The 8 bit arithemetic checksum and	other aspects allowed line
+   + The 8 bit arithmetic checksum and	other aspects allowed line
      impairments to interfere with dependable, accurate	transfers.
 
    + Only one file could be sent per command.  The file	name had to be
@@ -303,7 +303,7 @@ diff phone # into the dialing string and branches back to try it.
 This chapter discusses the protocol extensions to Ward Christensen's 1982
 XMODEM protocol	description document.
 
-The original document recommends the user be asked wether to continue
+The original document recommends the user be asked whether to continue
 trying or abort	after 10 retries.  Most	programs no longer ask the
 operator whether he wishes to keep retrying.  Virtually	all correctable
 errors are corrected within the	first few retransmissions.  If the line	is
@@ -845,7 +845,7 @@ bypasses the usual wait	for an ACK to each transmitted packet, sending
 succeeding packets at full speed, subject to XOFF/XON or other flow
 control	exerted	by the medium.
 
-The sender expects an inital G to initiate the transmission of a
+The sender expects an initial G to initiate the transmission of a
 particular file, and also expects an ACK on the	EOT sent at the	end of
 each file.  This synchronization allows	the receiver time to open and
 

--- a/xmodem/__init__.py
+++ b/xmodem/__init__.py
@@ -153,7 +153,7 @@ class XMODEM(object):
     :param getc: Function to retrieve bytes from a stream. The function takes
         the number of bytes to read from the stream and a timeout in seconds as
         parameters. It must return the bytes which were read, or ``None`` if a
-        timeout occured.
+        timeout occurred.
     :type getc: callable
     :param putc: Function to transmit bytes to a stream. The function takes the
         bytes to be written and a timeout in seconds as parameters. It must


### PR DESCRIPTION
The fixed typos were found via the following command:

`codespell -q 3`